### PR TITLE
Fixing proxy leak

### DIFF
--- a/src/dbus_bus.erl
+++ b/src/dbus_bus.erl
@@ -169,7 +169,8 @@ handle_info(Info, State) ->
     {noreply, State}.
 
 
-terminate(_Reason, _State) ->
+terminate(_Reason, #state{conn=Conn}=_State) ->
+  dbus_connection:close(Conn),
     terminated.
 
 

--- a/src/dbus_bus_connection.erl
+++ b/src/dbus_bus_connection.erl
@@ -37,7 +37,7 @@
 
 
 %% @doc Retrieve a bus_id from well-known names
-%% 
+%%
 %% @end
 -spec get_bus_id(dbus_known_bus()) -> bus_id() | {unsupported, [bus_id()]}.
 get_bus_id(session) ->
@@ -74,7 +74,7 @@ connect(#bus_id{}=BusId) ->
 		{ok, ConnId} ->
 		    case dbus_proxy:start_link(Conn, ?DBUS_SERVICE, <<"/">>, ?DBUS_NODE) of
 			{ok, DBus} ->
-			    ?debug("Acquired connection id: ~p~n", [ConnId]),	
+			    ?debug("Acquired connection id: ~p~n", [ConnId]),
 			    dbus_peer_connection:set_controlling_process(PConn, DBus),
 			    {ok, {?MODULE, DBus}};
 			{error, Err} -> {error, Err}
@@ -91,8 +91,8 @@ connect(BusName) when BusName =:= system;
 %% @doc Stop the bus proxy
 %% @end
 -spec close({?MODULE, dbus_connection()} | dbus_connection()) -> ok.
-close({?MODULE, Bus}) ->     dbus_proxy:stop(Bus);
-close(Bus) ->                dbus_proxy:stop(Bus).
+close({?MODULE, Bus}) ->     dbus_proxy:close(Bus);
+close(Bus) ->                dbus_proxy:close(Bus).
 
 
 %% @doc Send a message to the bus connection, synchronously.

--- a/src/dbus_remote_service.erl
+++ b/src/dbus_remote_service.erl
@@ -132,7 +132,7 @@ terminate(_Reason, _State) ->
 handle_release_object(Object, Pid, #state{objects=Reg}=State) ->
     ?debug("~p: ~p handle_release_object ~p~n", [?MODULE, self(), Object]),
     case ets:match_object(Reg, {'_', Object, '_'}) of
-	[{Path, _, Pids}] ->
+	[{Path, Object, Pids}] ->
 	    case sets:is_element(Pid, Pids) of
 		true ->
 		    true = unlink(Pid),
@@ -145,6 +145,7 @@ handle_release_object(Object, Pid, #state{objects=Reg}=State) ->
 			    case ets:info(Reg, size) of
 				0 ->
 				    ?debug("No more object in service, stopping service ~p~n", [State#state.name]),
+            dbus_proxy:stop(Object),
 				    {stop, State};
 				_ ->
 				    {ok, State}

--- a/src/dbus_remote_service.erl
+++ b/src/dbus_remote_service.erl
@@ -140,12 +140,12 @@ handle_release_object(Object, Pid, #state{objects=Reg}=State) ->
 		    case sets:size(Pids2) of
 			0 ->
 						% No more pids, remove object
-			    ?debug("object terminated ~p ~p~n", [Object, Path]),
-			    ets:delete(Reg, Path),
+            ?debug("object terminated ~p ~p~n", [Object, Path]),
+            ets:delete(Reg, Path),
+            dbus_proxy:stop(Object),
 			    case ets:info(Reg, size) of
 				0 ->
 				    ?debug("No more object in service, stopping service ~p~n", [State#state.name]),
-            dbus_proxy:stop(Object),
 				    {stop, State};
 				_ ->
 				    {ok, State}


### PR DESCRIPTION
Previously the `dbus_proxy` was leaking with his tcp connection. This lead to a ddos on the dbus bus and to a big memory leak. The fix is to close the connection part of `dbus_bus` `gen_server` and to stop the `dbus_proxy` from closing it. Their is always a proxy created when a connection is established and one per object queried. To make thing consistent, the `dbus_bus` server should handle the connection. The fix is
1. Remove the connection close from the proxy
1. Make a difference between a proxy stop and close. The stop should leave the connect untouch while  the close should close the connection has well. This is in line with the `dbus_connection` behaviour any way.
1. When no more object are own, then we should stop the proxy.