### PR TITLE
add the logger api

### DIFF
--- a/include/dbus.hrl
+++ b/include/dbus.hrl
@@ -7,8 +7,20 @@
 -ifndef(dbus_hrl).
 -define(dbus_hrl, true).
 
--if(?OTP_RELEASE < 21).
+-ifdef(OTP_RELEASE).
+-if(?OTP_RELEASE >= 21).
+-define(DBUS_LOGGER, logger).
+-else.
+-define(DBUS_LOGGER, error_logger).
+-endif.
+-endif.
 
+-ifndef(OTP_RELEASE).
+-define(DBUS_LOGGER, error_logger).
+-endif.
+
+
+-if(?DBUS_LOGGER =:= error_logger).
 -ifndef(debug).
 -define(debug(Msg), error_logger:info_msg(Msg)).
 -define(debug(Msg, Data), error_logger:info_msg(Msg, Data)).

--- a/include/dbus.hrl
+++ b/include/dbus.hrl
@@ -7,6 +7,8 @@
 -ifndef(dbus_hrl).
 -define(dbus_hrl, true).
 
+-if(?OTP_RELEASE < 21).
+
 -ifndef(debug).
 -define(debug(Msg), error_logger:info_msg(Msg)).
 -define(debug(Msg, Data), error_logger:info_msg(Msg, Data)).
@@ -25,6 +27,30 @@
 -ifndef(error).
 -define(error(Msg), error_logger:error_msg(Msg)).
 -define(error(Msg, Data), error_logger:error_msg(Msg, Data)).
+-endif.
+
+-else.
+-include_lib("kernel/include/logger.hrl").
+-ifndef(debug).
+-define(debug(Msg), ?LOG_DEBUG(lists:sublist(Msg, length(Msg)-2))).
+-define(debug(Msg, Data), ?LOG_DEBUG(lists:sublist(Msg, length(Msg)-2), Data)).
+-endif.
+
+-ifndef(info).
+-define(info(Msg), ?LOG_INFO(lists:sublist(Msg, length(Msg)-2))).
+-define(info(Msg, Data), ?LOG_INFO(lists:sublist(Msg, length(Msg)-2), Data)).
+-endif.
+
+-ifndef(warn).
+-define(warn(Msg), ?LOG_WARNING(lists:sublist(Msg, length(Msg)-2))).
+-define(warn(Msg, Data), ?LOG_WARNING(lists:sublist(Msg, length(Msg)-2), Data)).
+-endif.
+
+-ifndef(error).
+-define(error(Msg), ?LOG_ERROR(lists:sublist(Msg, length(Msg)-2))).
+-define(error(Msg, Data), ?LOG_ERROR(lists:sublist(Msg, length(Msg)-2), Data)).
+-endif.
+
 -endif.
 
 -define(DBUS_VERSION_MAJOR, 1).
@@ -63,10 +89,10 @@
 -type dbus_name() :: atom() | binary().
 -type dbus_option() :: no_reply_expected | no_auto_start.
 
--type dbus_type() :: byte | 
+-type dbus_type() :: byte |
                      boolean |
                      int16 |
-                     uint16 | 
+                     uint16 |
                      int32 |
                      uint32 |
                      int64 |
@@ -125,7 +151,7 @@
                               | 'org.freedesktop.DBus.Method.NoReply'
                               | 'org.freedesktop.DBus.Property.EmitsChangedSignal'
                               | binary().
--type dbus_annotation_value() :: true 
+-type dbus_annotation_value() :: true
                                | false
                                | invalidates
                                | binary().

--- a/src/dbus_auth_cookie_sha1.erl
+++ b/src/dbus_auth_cookie_sha1.erl
@@ -24,7 +24,7 @@ init() ->
     ?debug("Init DBUS_AUTH_COOKIE_SHA1 authentication~n", []),
     case os:getenv("USER") of
         false ->
-            ?error("DBUS_AUTH_COOKIE_SHA1 can not be used without USER env", []),
+            ?error("DBUS_AUTH_COOKIE_SHA1 can not be used without USER env~n", []),
             {error, invalid_user};
         User ->
             HexUser = dbus_hex:encode(list_to_binary(User)),
@@ -36,7 +36,7 @@ init() ->
 %% @end
 challenge(HexChall, waiting_challenge) ->
     Chall = dbus_hex:decode(HexChall),
-    ?debug("DBUS_COOKIE_SHA1 challenge: ~p", [Chall]),
+    ?debug("DBUS_COOKIE_SHA1 challenge: ~p~n", [Chall]),
     case binary:split(Chall, [<< $\s >>], [global]) of
         [Context, CookieId, ServerChallenge] ->
             case read_cookie(Context, CookieId) of

--- a/src/dbus_proxy.erl
+++ b/src/dbus_proxy.erl
@@ -379,7 +379,7 @@ do_introspect(Conn, Service, Path) ->
                     {error, parse_error}
             end;
         {ok, Msg} ->
-            ?error("Error introspecting object: ~p", [Msg]),
+            ?error("Error introspecting object: ~p~n", [Msg]),
             {error, invalid_introspect};
         {error, #dbus_message{body=Body}=Msg} ->
             Err = dbus_message:get_field(?FIELD_ERROR_NAME, Msg),
@@ -393,7 +393,7 @@ do_unique_name(Conn, Service) ->
         {ok, #dbus_message{body=Unique}} when is_binary(Unique) ->
             Unique;
         {ok, Msg} ->
-            ?error("Error getting name owner: ~p", [Msg]),
+            ?error("Error getting name owner: ~p~n", [Msg]),
             {error, invalid_nameowner};
         {error, #dbus_message{}=Err} ->
             case dbus_message:get_field(?FIELD_ERROR_NAME, Err) of
@@ -445,7 +445,7 @@ do_handle_signal(#signal_handler{mfa={Mod, Fun, Ctx}}=Handler, Acc, Sender, Ifac
         true ->
             try Mod:Fun(Sender, Iface, Signal, Path, Args, Ctx)
             catch Cls:Err ->
-                    ?error("Error dispatching signal to ~p:~p/6: ~p:~p", [Mod, Fun, Cls, Err])
+                    ?error("Error dispatching signal to ~p:~p/6: ~p:~p~n", [Mod, Fun, Cls, Err])
             end,
             [ Handler | Acc ];
         false -> Acc
@@ -454,7 +454,7 @@ do_handle_signal(#signal_handler{mfa={Mod, Fun, Ctx}}=Handler, Acc, Sender, Ifac
 do_handle_signal(#signal_handler{mfa={Fun, Ctx}}=Handler, Acc, Sender, Iface, Signal, Path, Args) ->
     try Fun(Sender, Iface, Signal, Path, Args, Ctx)
     catch Cls:Err ->
-            ?error("Error dispatching signal to ~p/6: ~p:~p", [Fun, Cls, Err])
+            ?error("Error dispatching signal to ~p/6: ~p:~p~n", [Fun, Cls, Err])
     end,
     [ Handler | Acc ];
 

--- a/src/dbus_transport_unix.erl
+++ b/src/dbus_transport_unix.erl
@@ -162,6 +162,6 @@ do_read(Sock, Pid) ->
             Pid ! {unix, list_to_binary(Buf)},
             do_read(Sock, Pid);
         Unhandled ->
-            ?debug("Unhandled receive: ~p", [Unhandled]),
+            ?debug("Unhandled receive: ~p~n", [Unhandled]),
             do_read(Sock, Pid)
     end.

--- a/test/dbus_client_SUITE.erl
+++ b/test/dbus_client_SUITE.erl
@@ -23,9 +23,9 @@
 %%%
 -compile([export_all]).
 
--define(dbus_session_tcp_anonymous, 
+-define(dbus_session_tcp_anonymous,
 	{"session_tcp_anonymous.conf", "tcp:host=localhost,bind=*,port=55555,family=ipv4"}).
--define(dbus_session_unix_anonymous, 
+-define(dbus_session_unix_anonymous,
 	{"session_unix_anonymous.conf", "unix:path=/tmp/dbus-test"}).
 -define(dbus_session_unix_external,
 	{"session_unix_external.conf", "unix:path=/tmp/dbus-test"}).
@@ -89,7 +89,7 @@ init_per_group(_Name, Config) ->
     [ {service_port, ServicePid}, {connect, true} | Config0 ].
 
 
-end_per_group(Group, Config) 
+end_per_group(Group, Config)
   when Group =:= connect_tcp_anonymous;
        Group =:= connect_unix_anonymous;
        Group =:= connect_unix_external ->
@@ -145,7 +145,7 @@ interface(Config) ->
     {ok, O} = dbus_proxy:start_link(?config(bus, Config), ?SERVICE, <<"/root">>),
     ?assertMatch(true, dbus_proxy:has_interface(O, ?IFACE)),
     ?assertMatch(false, dbus_proxy:has_interface(O, <<"toto">>)),
-    ok.        
+    ok.
 
 call_method(Config) ->
     {ok, O} = dbus_proxy:start_link(?config(bus, Config), ?SERVICE, <<"/root">>),
@@ -208,11 +208,11 @@ signal(Config) ->
                ([ Signal | Signals ], [], F) ->
                    receive Signal -> F(lists:delete(Signal, Signals), [], F)
                    after 100 -> ?assert(false)
-                   end;        
+                   end;
                ([], [ BadSignal | BadSignals ], F) ->
                    receive BadSignal -> ?assert(false)
                    after 100 -> F([], BadSignals, F)
-                   end;        
+                   end;
                ([ Signal | Signals ], [ BadSignal | BadSignals ], F) ->
                    receive Signal -> F(lists:delete(Signal, Signals), [ BadSignal | BadSignals ], F);
                            BadSignal -> ?assert(false)
@@ -238,7 +238,7 @@ start_dbus(Config, {DBusConfig, DBusEnv}) ->
 
 stop_dbus(Config) ->
     stop_cmd(?config(dbus, Config)),
-    proplists:delete(dbus_env, 
+    proplists:delete(dbus_env,
 		     proplists:delete(dbus, Config)).
 
 


### PR DESCRIPTION
Add support to log via the logger api on otp >= 21. In this mode, the trailling new line (`~n`) is remove from the format string. This make formatting with a custom formater more intuitive. To make sure we are not removing other format option, all the log line must add a `~n` at the end.